### PR TITLE
BUG: Fix build errors and warnings.

### DIFF
--- a/include/itkMultiScaleHessianEnhancementImageFilter.h
+++ b/include/itkMultiScaleHessianEnhancementImageFilter.h
@@ -78,7 +78,7 @@ public:
 
   /** Image related typedefs. */
   typedef typename TInputImage::PixelType  PixelType;
-  itkStaticConstMacro(ImageDimension, unsigned int,  TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Hessian related typedefs. */
   typedef HessianRecursiveGaussianImageFilter< TInputImage >  HessianFilterType;
@@ -128,9 +128,9 @@ public:
    * Note that these methods cannot throw exceptions according to the standard itkExceptionMacro since they are static
    * methods. Instead, they will return an empty sigma array on error.
    */
-  static Self::SigmaArrayType GenerateSigmaArray(SigmaType SigmaMinimum, SigmaType SigmaMaximum, SigmaStepsType NumberOfSigmaSteps, SigmaStepMethodEnum SigmaStepMethod);
-  static Self::SigmaArrayType GenerateEquispacedSigmaArray(SigmaType SigmaMinimum, SigmaType SigmaMaximum, SigmaStepsType NumberOfSigmaSteps);
-  static Self::SigmaArrayType GenerateLogarithmicSigmaArray(SigmaType SigmaMinimum, SigmaType SigmaMaximum, SigmaStepsType NumberOfSigmaSteps);
+  static SigmaArrayType GenerateSigmaArray(SigmaType SigmaMinimum, SigmaType SigmaMaximum, SigmaStepsType NumberOfSigmaSteps, SigmaStepMethodEnum SigmaStepMethod);
+  static SigmaArrayType GenerateEquispacedSigmaArray(SigmaType SigmaMinimum, SigmaType SigmaMaximum, SigmaStepsType NumberOfSigmaSteps);
+  static SigmaArrayType GenerateLogarithmicSigmaArray(SigmaType SigmaMinimum, SigmaType SigmaMaximum, SigmaStepsType NumberOfSigmaSteps);
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
@@ -144,7 +144,7 @@ protected:
   virtual ~MultiScaleHessianEnhancementImageFilter() {}
 
   /** Single threaded since we are connecting data */
-  void GenerateData() ITK_OVERRIDE;
+  void GenerateData() override;
 
   /** Internal function to generate the response at a scale */
   inline typename TOutputImage::Pointer generateResponseAtScale(SigmaStepsType scaleLevel);
@@ -153,12 +153,12 @@ protected:
   InternalEigenValueOrderType ConvertType(ExternalEigenValueOrderType order);
 
   /** Override since the filter needs all the data for the algorithm */
-  void GenerateInputRequestedRegion() ITK_OVERRIDE;
+  void GenerateInputRequestedRegion() override;
 
   /** Override since the filter produces all of its output */
-  void EnlargeOutputRequestedRegion(DataObject *data) ITK_OVERRIDE;
+  void EnlargeOutputRequestedRegion(DataObject *data) override;
 
-  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
+  void PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
   /** Internal filters. */

--- a/test/itkMultiScaleHessianEnhancementImageFilterStaticMethodsTest.cxx
+++ b/test/itkMultiScaleHessianEnhancementImageFilterStaticMethodsTest.cxx
@@ -32,23 +32,12 @@ int itkMultiScaleHessianEnhancementImageFilterStaticMethodsTest( int, char * [] 
   /* Test the two cases of step size zero */
   ArrayType sigmaArray;
   bool exceptionCaught = false;
-  try
-  {
-    sigmaArray = MultiScaleHessianEnhancementImageFilterType::GenerateLogarithmicSigmaArray(5, 5, 0);
-  }
-  catch( itk::ExceptionObject & err ) {
-    exceptionCaught = true;
-  }
-  TEST_EXPECT_TRUE(exceptionCaught);
-  exceptionCaught = false;
-  try
-  {
-    sigmaArray = MultiScaleHessianEnhancementImageFilterType::GenerateEquispacedSigmaArray(5, 5, 0);
-  }
-  catch( itk::ExceptionObject & err ) {
-    exceptionCaught = true;
-  }
-  TEST_EXPECT_TRUE(exceptionCaught);
+
+  TRY_EXPECT_EXCEPTION(
+    sigmaArray = MultiScaleHessianEnhancementImageFilterType::GenerateLogarithmicSigmaArray(5, 5, 0));
+
+  TRY_EXPECT_EXCEPTION(
+    sigmaArray = MultiScaleHessianEnhancementImageFilterType::GenerateEquispacedSigmaArray(5, 5, 0) );
 
   /* Test that we get one when min equals max */
   ArrayType expectedOneSigmaArray;


### PR DESCRIPTION
Address the following build errors:
```
ITKBoneEnhancement\include\itkMultiScaleHessianEnhancementImageFilter.h(131):
error C2061: syntax error: identifier 'SigmaArrayType'
ITKBoneEnhancement\include\itkMultiScaleHessianEnhancementImageFilter.h(131):
error C2238: unexpected token(s) preceding ';'
```

and the following warnings:
```
ITKBoneEnhancement\include\itkMultiScaleHessianEnhancementImageFilter.h(131):
note: prefix with 'typename' to indicate a type
ITKBoneEnhancement\include\itkMultiScaleHessianEnhancementImageFilter.h(174):
note: see reference to class template instantiation
'itk::MultiScaleHessianEnhancementImageFilter<TInputImage,TOutputImage>'
being compiled
ITKBoneEnhancement\test\itkMultiScaleHessianEnhancementImageFilterStaticMethodsTest.cxx(39):
warning C4101: 'err': unreferenced local variable
ITKBoneEnhancement\test\itkMultiScaleHessianEnhancementImageFilterStaticMethodsTest.cxx(48):
warning C4101: 'err': unreferenced local variable

```