### PR TITLE
STYLE: Use "typename" for template parameters

### DIFF
--- a/include/itkDescoteauxEigenToScalarFunctorImageFilter.h
+++ b/include/itkDescoteauxEigenToScalarFunctorImageFilter.h
@@ -48,7 +48,7 @@ namespace Functor {
  * \author: Bryce Besler
  * \ingroup BoneEnhancement
  */
-template<class TInputPixel, class TOutputPixel>
+template<typename TInputPixel, typename TOutputPixel>
 class DescoteauxEigenToScalarFunctor {
 public:
   /* Basic type definitions */

--- a/include/itkKrcahEigenToScalarFunctorImageFilter.h
+++ b/include/itkKrcahEigenToScalarFunctorImageFilter.h
@@ -45,7 +45,7 @@ namespace Functor {
  * \author: Thomas Fitze
  * \ingroup BoneEnhancement
  */
-template<class TInputPixel, class TOutputPixel>
+template<typename TInputPixel, typename TOutputPixel>
 class KrcahEigenToScalarFunctor {
 public:
   /* Basic type definitions */


### PR DESCRIPTION
For naming template parameters, typename and class are equivalent. ref:14.1.2: There is no semantic difference between class and typename in a template-parameter.

The primary purpose of this patch set is to make ITK consistent so that an enforcable style can be implemented.  The ITK Style guide as been updated to reflect this change [1].

For tempalate parameters the use of "typename" is preferred over "class". Very early c++ compilers did not have a "typename" keyword, and "class" was repurposed for declaring template parameters. It was later discovered that this lead to ambiguity in some valid code constructs, and the "typename" key
word was added. It is sometimes stated [2] that "typename" is marginally more expressive in it's intent and ITK should consistently use "typename" instead of "class".

[1] http://www.vtk.org/Wiki/ITK/Coding_Style_Guide
[2] http://blogs.msdn.com/b/slippman/archive/2004/08/11/212768.aspx