### PR TITLE
STYLE: Prefer C++11 type alias over typedef.

### DIFF
--- a/example/computeDescoteauxBoneEnhancement.cxx
+++ b/example/computeDescoteauxBoneEnhancement.cxx
@@ -79,17 +79,15 @@ int main(int argc, char * argv[])
 
   /* Setup Types */
   constexpr unsigned int ImageDimension = 3;
-  typedef short                                       InputPixelType;
-  typedef itk::Image<InputPixelType, ImageDimension>  InputImageType;
-  typedef float                                       OutputPixelType;
-  typedef itk::Image<OutputPixelType, ImageDimension> OutputImageType;
+  using InputPixelType = short;
+  using InputImageType = itk::Image<InputPixelType, ImageDimension>;
+  using OutputPixelType = float;
+  using OutputImageType = itk::Image<OutputPixelType, ImageDimension>;
 
-  typedef itk::ImageFileReader< InputImageType >      ReaderType;
-  typedef itk::ImageFileWriter< OutputImageType >     MeasureWriterType;
-  typedef itk::MultiScaleHessianEnhancementImageFilter< InputImageType, OutputImageType >
-                                                      MultiScaleHessianFilterType;
-  typedef itk::DescoteauxEigenToScalarImageFilter< MultiScaleHessianFilterType::EigenValueImageType, OutputImageType >
-                                                      DescoteauxEigenToScalarImageFilterType;
+  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using MeasureWriterType = itk::ImageFileWriter< OutputImageType >;
+  using MultiScaleHessianFilterType = itk::MultiScaleHessianEnhancementImageFilter< InputImageType, OutputImageType >;
+  using DescoteauxEigenToScalarImageFilterType = itk::DescoteauxEigenToScalarImageFilter< MultiScaleHessianFilterType::EigenValueImageType, OutputImageType >;
 
   /* Do preprocessing */
   std::cout << "Reading in " << inputFileName << std::end;

--- a/example/computeKrcahBoneEnhancement.cxx
+++ b/example/computeKrcahBoneEnhancement.cxx
@@ -89,20 +89,17 @@ int main(int argc, char * argv[])
 
   /* Setup Types */
   constexpr unsigned int ImageDimension = 3;
-  typedef short                                       InputPixelType;
-  typedef itk::Image<InputPixelType, ImageDimension>  InputImageType;
-  typedef float                                       OutputPixelType;
-  typedef itk::Image<OutputPixelType, ImageDimension> OutputImageType;
+  using InputPixelType = short;
+  using InputImageType = itk::Image<InputPixelType, ImageDimension>;
+  using OutputPixelType = float;
+  using OutputImageType = itk::Image<OutputPixelType, ImageDimension>;
 
-  typedef itk::ImageFileReader< InputImageType >      ReaderType;
-  typedef itk::ImageFileWriter< InputImageType >      PreprocessedWriterType;
-  typedef itk::ImageFileWriter< OutputImageType >     MeasureWriterType;
-  typedef itk::KrcahEigenToScalarPreprocessingImageToImageFilter< InputImageType >
-                                                      PreprocessFilterType;
-  typedef itk::MultiScaleHessianEnhancementImageFilter< InputImageType, OutputImageType >
-                                                      MultiScaleHessianFilterType;
-  typedef itk::KrcahEigenToScalarImageFilter< MultiScaleHessianFilterType::EigenValueImageType, OutputImageType >
-                                                      KrcahEigenToScalarFilterType;
+  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using PreprocessedWriterType = itk::ImageFileWriter< InputImageType >;
+  using MeasureWriterType = itk::ImageFileWriter< OutputImageType >;
+  using PreprocessFilterType = itk::KrcahEigenToScalarPreprocessingImageToImageFilter< InputImageType >;
+  using MultiScaleHessianFilterType = itk::MultiScaleHessianEnhancementImageFilter< InputImageType, OutputImageType >;
+  using KrcahEigenToScalarFilterType = itk::KrcahEigenToScalarImageFilter< MultiScaleHessianFilterType::EigenValueImageType, OutputImageType >;
 
   /* Do preprocessing */
   ReaderType::Pointer  reader = ReaderType::New();

--- a/include/itkDescoteauxEigenToScalarFunctorImageFilter.h
+++ b/include/itkDescoteauxEigenToScalarFunctorImageFilter.h
@@ -52,7 +52,7 @@ template<class TInputPixel, class TOutputPixel>
 class DescoteauxEigenToScalarFunctor {
 public:
   /* Basic type definitions */
-  typedef typename NumericTraits< TOutputPixel >::RealType  RealType;
+  using RealType = typename NumericTraits< TOutputPixel >::RealType;
 
   DescoteauxEigenToScalarFunctor() :
     m_Direction(-1.0)
@@ -162,15 +162,14 @@ class DescoteauxEigenToScalarFunctorImageFilter :
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(DescoteauxEigenToScalarFunctorImageFilter);
 
-  /** Standard Self typedef */
-  typedef DescoteauxEigenToScalarFunctorImageFilter Self;
-  typedef UnaryFunctorImageFilter<TInputImage, TOutputImage,
-          Functor::DescoteauxEigenToScalarFunctor<typename TInputImage::PixelType, typename TOutputImage::PixelType > >
-                                                    Superclass;
-  typedef SmartPointer<Self>                        Pointer;
-  typedef SmartPointer<const Self>                  ConstPointer;
+  /** Standard Self type alias */
+  using Self = DescoteauxEigenToScalarFunctorImageFilter;
+  using Superclass = UnaryFunctorImageFilter<TInputImage, TOutputImage,
+          Functor::DescoteauxEigenToScalarFunctor<typename TInputImage::PixelType, typename TOutputImage::PixelType > >;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
-  /** Useful typedefs for numerics */
+  /** Useful type alias for numerics */
   typedef typename Functor::DescoteauxEigenToScalarFunctor<typename TInputImage::PixelType, typename TOutputImage::PixelType > 
                     DescoteauxFunctorType;
   typedef typename DescoteauxFunctorType::RealType
@@ -183,7 +182,7 @@ public:
   itkTypeMacro(DescoteauxEigenToScalarFunctorImageFilter, UnaryFunctorImageFilter);
 
   /** Define decorator types */
-  typedef SimpleDataObjectDecorator< RealType > InputParameterDecoratorType;
+  using InputParameterDecoratorType = SimpleDataObjectDecorator< RealType >;
 
   /** Process object */
   itkSetGetDecoratedInputMacro(Alpha, RealType);

--- a/include/itkDescoteauxEigenToScalarImageFilter.h
+++ b/include/itkDescoteauxEigenToScalarImageFilter.h
@@ -52,11 +52,11 @@ public EigenToScalarImageFilter< TInputImage, TOutputImage >
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(DescoteauxEigenToScalarImageFilter);
 
-  /** Standard Self typedef */
-  typedef DescoteauxEigenToScalarImageFilter                    Self;
-  typedef EigenToScalarImageFilter< TInputImage, TOutputImage > Superclass;
-  typedef SmartPointer< Self >                                  Pointer;
-  typedef SmartPointer< const Self >                            ConstPointer;
+  /** Standard Self type alias */
+  using Self = DescoteauxEigenToScalarImageFilter;
+  using Superclass = EigenToScalarImageFilter< TInputImage, TOutputImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -64,18 +64,16 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(DescoteauxEigenToScalarImageFilter, EigenToScalarImageFilter);
 
-  /** Useful template typedefs. */
-  typedef typename TInputImage::Pointer       InputImagePointer;
-  typedef typename TInputImage::ConstPointer  InputImageConstPointer;
-  typedef typename TMaskImage::Pointer        MaskImagePointer;
-  typedef typename TMaskImage::ConstPointer   MaskImageConstPointer;
-  typedef typename TMaskImage::PixelType      MaskPixelType;
+  /** Useful template type alias. */
+  using InputImagePointer = typename TInputImage::Pointer;
+  using InputImageConstPointer = typename TInputImage::ConstPointer;
+  using MaskImagePointer = typename TMaskImage::Pointer;
+  using MaskImageConstPointer = typename TMaskImage::ConstPointer;
+  using MaskPixelType = typename TMaskImage::PixelType;
 
   /** Procesing filters */
-  typedef DescoteauxEigenToScalarParameterEstimationImageFilter< TInputImage, TMaskImage >
-            ParameterEstimationFilterType;
-  typedef DescoteauxEigenToScalarFunctorImageFilter< TInputImage, TOutputImage >
-            UnaryFunctorFilterType;
+  using ParameterEstimationFilterType = DescoteauxEigenToScalarParameterEstimationImageFilter< TInputImage, TMaskImage >;
+  using UnaryFunctorFilterType = DescoteauxEigenToScalarFunctorImageFilter< TInputImage, TOutputImage >;
 
   /** Explicitely state the eigenvalues are ordered by magnitude for this filter */
   typename Superclass::EigenValueOrderType GetEigenValueOrder() const override

--- a/include/itkDescoteauxEigenToScalarParameterEstimationImageFilter.h
+++ b/include/itkDescoteauxEigenToScalarParameterEstimationImageFilter.h
@@ -55,11 +55,11 @@ public ImageToImageFilter< TInputImage, TInputImage >
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(DescoteauxEigenToScalarParameterEstimationImageFilter);
 
-  /** Standard Self typedef */
-  typedef DescoteauxEigenToScalarParameterEstimationImageFilter Self;
-  typedef ImageToImageFilter< TInputImage, TInputImage >        Superclass;
-  typedef SmartPointer< Self >                                  Pointer;
-  typedef SmartPointer< const Self >                            ConstPointer;
+  /** Standard Self type alias */
+  using Self = DescoteauxEigenToScalarParameterEstimationImageFilter;
+  using Superclass = ImageToImageFilter< TInputImage, TInputImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -67,27 +67,27 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(DescoteauxEigenToScalarParameterEstimationImageFilter, ImageToImageFilter);
 
-  /** Image related typedefs. */
-  typedef typename TInputImage::Pointer       InputImagePointer;
-  typedef typename TInputImage::ConstPointer  InputImageConstPointer;
-  typedef typename TInputImage::RegionType    InputRegionType;
-  typedef typename TInputImage::SizeType      InputSizeType;
-  typedef typename TInputImage::IndexType     InputIndexType;
-  typedef typename TInputImage::PixelType     InputPixelType;
-  typedef typename InputPixelType::ValueType  InputPixelValueType;
+  /** Image related type alias. */
+  using InputImagePointer = typename TInputImage::Pointer;
+  using InputImageConstPointer = typename TInputImage::ConstPointer;
+  using InputRegionType = typename TInputImage::RegionType;
+  using InputSizeType = typename TInputImage::SizeType;
+  using InputIndexType = typename TInputImage::IndexType;
+  using InputPixelType = typename TInputImage::PixelType;
+  using InputPixelValueType = typename InputPixelType::ValueType;
 
   /** Output region definitions */
-  typedef InputRegionType OutputRegionType;
+  using OutputRegionType = InputRegionType;
 
-  /** Mask related typedefs. */
-  typedef typename TMaskImage::Pointer      MaskImagePointer;
-  typedef typename TMaskImage::ConstPointer MaskImageConstPointer;
-  typedef typename TMaskImage::PixelType    MaskPixelType;
-  typedef typename TMaskImage::RegionType   MaskRegionType;
+  /** Mask related type alias. */
+  using MaskImagePointer = typename TMaskImage::Pointer;
+  using MaskImageConstPointer = typename TMaskImage::ConstPointer;
+  using MaskPixelType = typename TMaskImage::PixelType;
+  using MaskRegionType = typename TMaskImage::RegionType;
 
   /** Parameters */
-  typedef typename NumericTraits< InputPixelValueType >::RealType RealType;
-  typedef SimpleDataObjectDecorator< RealType >                   RealTypeDecoratedType;
+  using RealType = typename NumericTraits< InputPixelValueType >::RealType;
+  using RealTypeDecoratedType = SimpleDataObjectDecorator< RealType >;
 
   /** Methods to set/get the mask image */
   itkSetInputMacro(MaskImage, TMaskImage);

--- a/include/itkEigenToScalarImageFilter.h
+++ b/include/itkEigenToScalarImageFilter.h
@@ -42,11 +42,11 @@ public ImageToImageFilter< TInputImage, TOutputImage >
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(EigenToScalarImageFilter);
 
-  /** Standard Self typedef */
-  typedef EigenToScalarImageFilter                        Self;
-  typedef ImageToImageFilter< TInputImage, TOutputImage > Superclass;
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  /** Standard Self type alias */
+  using Self = EigenToScalarImageFilter;
+  using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Run-time type information (and related methods). */
   itkTypeMacro(EigenToScalarImageFilter, ImageToImageFilter);

--- a/include/itkKrcahEigenToScalarFunctorImageFilter.h
+++ b/include/itkKrcahEigenToScalarFunctorImageFilter.h
@@ -49,7 +49,7 @@ template<class TInputPixel, class TOutputPixel>
 class KrcahEigenToScalarFunctor {
 public:
   /* Basic type definitions */
-  typedef typename NumericTraits< TOutputPixel >::RealType  RealType;
+  using RealType = typename NumericTraits< TOutputPixel >::RealType;
 
   KrcahEigenToScalarFunctor() :
     m_Direction(-1.0)
@@ -156,17 +156,16 @@ class KrcahEigenToScalarFunctorImageFilter :
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(KrcahEigenToScalarFunctorImageFilter);
 
-  /** Standard Self typedef */
-  typedef KrcahEigenToScalarFunctorImageFilter  Self;
-  typedef UnaryFunctorImageFilter<TInputImage, TOutputImage,
-          Functor::KrcahEigenToScalarFunctor<typename TInputImage::PixelType, typename TOutputImage::PixelType > >
-                                                Superclass;
-  typedef SmartPointer<Self>                    Pointer;
-  typedef SmartPointer<const Self>              ConstPointer;
+  /** Standard Self type alias */
+  using Self = KrcahEigenToScalarFunctorImageFilter;
+  using Superclass = UnaryFunctorImageFilter<TInputImage, TOutputImage,
+          Functor::KrcahEigenToScalarFunctor<typename TInputImage::PixelType, typename TOutputImage::PixelType > >;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
-  /** Useful typedefs for numerics */
-  typedef typename Functor::KrcahEigenToScalarFunctor<typename TInputImage::PixelType, typename TOutputImage::PixelType > KrcahFunctorType;
-  typedef typename KrcahFunctorType::RealType                                                                             RealType;
+  /** Useful type alias for numerics */
+  using KrcahFunctorType = typename Functor::KrcahEigenToScalarFunctor<typename TInputImage::PixelType, typename TOutputImage::PixelType >;
+  using RealType = typename KrcahFunctorType::RealType;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -175,7 +174,7 @@ public:
   itkTypeMacro(KrcahEigenToScalarFunctorImageFilter, UnaryFunctorImageFilter);
 
   /** Define decorator types */
-  typedef SimpleDataObjectDecorator< RealType > InputParameterDecoratorType;
+  using InputParameterDecoratorType = SimpleDataObjectDecorator< RealType >;
 
   /** Process object */
   itkSetGetDecoratedInputMacro(Alpha, RealType);

--- a/include/itkKrcahEigenToScalarImageFilter.h
+++ b/include/itkKrcahEigenToScalarImageFilter.h
@@ -52,11 +52,11 @@ public EigenToScalarImageFilter< TInputImage, TOutputImage >
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(KrcahEigenToScalarImageFilter);
 
-  /** Standard Self typedef */
-  typedef KrcahEigenToScalarImageFilter                         Self;
-  typedef EigenToScalarImageFilter< TInputImage, TOutputImage > Superclass;
-  typedef SmartPointer< Self >                                  Pointer;
-  typedef SmartPointer< const Self >                            ConstPointer;
+  /** Standard Self type alias */
+  using Self = KrcahEigenToScalarImageFilter;
+  using Superclass = EigenToScalarImageFilter< TInputImage, TOutputImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -64,17 +64,17 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(KrcahEigenToScalarImageFilter, EigenToScalarImageFilter);
 
-  /** Useful template typedefs. */
-  typedef typename TInputImage::Pointer       InputImagePointer;
-  typedef typename TInputImage::ConstPointer  InputImageConstPointer;
-  typedef typename TMaskImage::Pointer        MaskImagePointer;
-  typedef typename TMaskImage::ConstPointer   MaskImageConstPointer;
-  typedef typename TMaskImage::PixelType      MaskPixelType;
+  /** Useful template type alias. */
+  using InputImagePointer = typename TInputImage::Pointer;
+  using InputImageConstPointer = typename TInputImage::ConstPointer;
+  using MaskImagePointer = typename TMaskImage::Pointer;
+  using MaskImageConstPointer = typename TMaskImage::ConstPointer;
+  using MaskPixelType = typename TMaskImage::PixelType;
 
   /** Procesing filters */
-  typedef KrcahEigenToScalarParameterEstimationImageFilter< TInputImage, TMaskImage >   ParameterEstimationFilterType;
-  typedef typename ParameterEstimationFilterType::KrcahImplementationType               KrcahImplementationType;
-  typedef KrcahEigenToScalarFunctorImageFilter< TInputImage, TOutputImage >             UnaryFunctorFilterType;
+  using ParameterEstimationFilterType = KrcahEigenToScalarParameterEstimationImageFilter< TInputImage, TMaskImage >;
+  using KrcahImplementationType = typename ParameterEstimationFilterType::KrcahImplementationType;
+  using UnaryFunctorFilterType = KrcahEigenToScalarFunctorImageFilter< TInputImage, TOutputImage >;
 
   /** Explicitely state the eigenvalues are ordered by magnitude for this filter */
   typename Superclass::EigenValueOrderType GetEigenValueOrder() const override

--- a/include/itkKrcahEigenToScalarParameterEstimationImageFilter.h
+++ b/include/itkKrcahEigenToScalarParameterEstimationImageFilter.h
@@ -82,11 +82,11 @@ public ImageToImageFilter< TInputImage, TInputImage >
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(KrcahEigenToScalarParameterEstimationImageFilter);
 
-  /** Standard Self typedef */
-  typedef KrcahEigenToScalarParameterEstimationImageFilter      Self;
-  typedef ImageToImageFilter< TInputImage, TInputImage >        Superclass;
-  typedef SmartPointer< Self >                                  Pointer;
-  typedef SmartPointer< const Self >                            ConstPointer;
+  /** Standard Self type alias */
+  using Self = KrcahEigenToScalarParameterEstimationImageFilter;
+  using Superclass = ImageToImageFilter< TInputImage, TInputImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -94,23 +94,23 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(KrcahEigenToScalarParameterEstimationImageFilter, ImageToImageFilter);
 
-  /** Image related typedefs. */
-  typedef typename TInputImage::Pointer       InputImagePointer;
-  typedef typename TInputImage::ConstPointer  InputImageConstPointer;
-  typedef typename TInputImage::RegionType    InputRegionType;
-  typedef typename TInputImage::SizeType      InputSizeType;
-  typedef typename TInputImage::IndexType     InputIndexType;
-  typedef typename TInputImage::PixelType     InputPixelType;
-  typedef typename InputPixelType::ValueType  InputPixelValueType;
+  /** Image related type alias. */
+  using InputImagePointer = typename TInputImage::Pointer;
+  using InputImageConstPointer = typename TInputImage::ConstPointer;
+  using InputRegionType = typename TInputImage::RegionType;
+  using InputSizeType = typename TInputImage::SizeType;
+  using InputIndexType = typename TInputImage::IndexType;
+  using InputPixelType = typename TInputImage::PixelType;
+  using InputPixelValueType = typename InputPixelType::ValueType;
 
   /** Output region definitions */
-  typedef InputRegionType OutputRegionType;
+  using OutputRegionType = InputRegionType;
 
-  /** Mask related typedefs. */
-  typedef typename TMaskImage::Pointer      MaskImagePointer;
-  typedef typename TMaskImage::ConstPointer MaskImageConstPointer;
-  typedef typename TMaskImage::PixelType    MaskPixelType;
-  typedef typename TMaskImage::RegionType   MaskRegionType;
+  /** Mask related type alias. */
+  using MaskImagePointer = typename TMaskImage::Pointer;
+  using MaskImageConstPointer = typename TMaskImage::ConstPointer;
+  using MaskPixelType = typename TMaskImage::PixelType;
+  using MaskRegionType = typename TMaskImage::RegionType;
 
   /** Methods to set/get the mask image */
   itkSetInputMacro(MaskImage, TMaskImage);
@@ -137,8 +137,8 @@ public:
   }
 
   /** Parameters */
-  typedef typename NumericTraits< InputPixelValueType >::RealType RealType;
-  typedef SimpleDataObjectDecorator< RealType >                   RealTypeDecoratedType;
+  using RealType = typename NumericTraits< InputPixelValueType >::RealType;
+  using RealTypeDecoratedType = SimpleDataObjectDecorator< RealType >;
 
   /** Decorators for parameters so they can be passed as a process object */
   RealTypeDecoratedType * GetAlphaOutput();

--- a/include/itkKrcahEigenToScalarPreprocessingImageToImageFilter.h
+++ b/include/itkKrcahEigenToScalarPreprocessingImageToImageFilter.h
@@ -58,11 +58,11 @@ public ImageToImageFilter< TInputImage, TOutputImage >
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(KrcahEigenToScalarPreprocessingImageToImageFilter);
 
-  /** Standard Self typedef */
-  typedef KrcahEigenToScalarPreprocessingImageToImageFilter Self;
-  typedef ImageToImageFilter< TInputImage, TOutputImage >   Superclass;
-  typedef SmartPointer< Self >                              Pointer;
-  typedef SmartPointer< const Self >                        ConstPointer;
+  /** Standard Self type alias */
+  using Self = KrcahEigenToScalarPreprocessingImageToImageFilter;
+  using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -74,17 +74,17 @@ public:
    * of the two images is assumed to be the same. */
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
-  /** Image related typedefs. */
-  typedef typename TInputImage::PixelType                     PixelType;
-  typedef typename TOutputImage::PixelType                    OutputPixelType;
-  typedef typename NumericTraits< PixelType >::RealType       RealType;
-  typedef typename NumericTraits<OutputPixelType>::ValueType  OutputPixelValueType;
+  /** Image related type alias. */
+  using PixelType = typename TInputImage::PixelType;
+  using OutputPixelType = typename TOutputImage::PixelType;
+  using RealType = typename NumericTraits< PixelType >::RealType;
+  using OutputPixelValueType = typename NumericTraits<OutputPixelType>::ValueType;
 
   /** Typedefs for internal filters */
-  typedef DiscreteGaussianImageFilter<TInputImage, TInputImage>       GaussianFilterType;
-  typedef SubtractImageFilter<TInputImage, TInputImage, TInputImage>  SubstractFilterType;
-  typedef MultiplyImageFilter<TInputImage, TInputImage, TInputImage>  MultiplyFilterType;
-  typedef AddImageFilter<TInputImage, TInputImage, TOutputImage>      AddFilterType;
+  using GaussianFilterType = DiscreteGaussianImageFilter<TInputImage, TInputImage>;
+  using SubstractFilterType = SubtractImageFilter<TInputImage, TInputImage, TInputImage>;
+  using MultiplyFilterType = MultiplyImageFilter<TInputImage, TInputImage, TInputImage>;
+  using AddFilterType = AddImageFilter<TInputImage, TInputImage, TOutputImage>;
 
   /** Flag to release data or not */
   itkSetMacro(ReleaseInternalFilterData, bool);

--- a/include/itkMaximumAbsoluteValueImageFilter.h
+++ b/include/itkMaximumAbsoluteValueImageFilter.h
@@ -70,16 +70,16 @@ Functor::MaximumAbsoluteValue<typename TInputImage1::PixelType, typename TInputI
 public:
     ITK_DISALLOW_COPY_AND_ASSIGN(MaximumAbsoluteValueImageFilter);
 
-  /** Standard Self typedef */
-  typedef MaximumAbsoluteValueImageFilter Self;
-  typedef BinaryFunctorImageFilter<TInputImage1, TInputImage2, TOutputImage,
+  /** Standard Self type alias */
+  using Self = MaximumAbsoluteValueImageFilter;
+  using Superclass = BinaryFunctorImageFilter<TInputImage1, TInputImage2, TOutputImage,
           Functor::MaximumAbsoluteValue<typename TInputImage1::PixelType, typename TInputImage2::PixelType,
-                  typename TOutputImage::PixelType> > Superclass;
-  typedef SmartPointer<Self>                          Pointer;
-  typedef SmartPointer<const Self>                    ConstPointer;
-  typedef typename TInputImage1::PixelType            Input1PixelType;
-  typedef typename TInputImage2::PixelType            Input2PixelType;
-  typedef typename TOutputImage::PixelType            OutputPixelType;
+                  typename TOutputImage::PixelType> >;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
+  using Input1PixelType = typename TInputImage1::PixelType;
+  using Input2PixelType = typename TInputImage2::PixelType;
+  using OutputPixelType = typename TOutputImage::PixelType;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/itkMultiScaleHessianEnhancementImageFilter.h
+++ b/include/itkMultiScaleHessianEnhancementImageFilter.h
@@ -66,11 +66,11 @@ public ImageToImageFilter< TInputImage, TOutputImage >
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(MultiScaleHessianEnhancementImageFilter);
 
-  /** Standard Self typedef */
-  typedef MultiScaleHessianEnhancementImageFilter         Self;
-  typedef ImageToImageFilter< TInputImage, TOutputImage > Superclass;
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  /** Standard Self type alias */
+  using Self = MultiScaleHessianEnhancementImageFilter;
+  using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -78,43 +78,43 @@ public:
   /** Runtime information support. */
   itkTypeMacro(MultiScaleHessianEnhancementImageFilter, ImageToImageFilter);
 
-  /** Image related typedefs. */
-  typedef typename TInputImage::PixelType  PixelType;
+  /** Image related type alias. */
+  using PixelType = typename TInputImage::PixelType;
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
-  /** Hessian related typedefs. */
-  typedef HessianRecursiveGaussianImageFilter< TInputImage >  HessianFilterType;
-  typedef typename HessianFilterType::OutputImageType         HessianImageType;
-  typedef typename HessianImageType::PixelType                HessianPixelType;
+  /** Hessian related type alias. */
+  using HessianFilterType = HessianRecursiveGaussianImageFilter< TInputImage >;
+  using HessianImageType = typename HessianFilterType::OutputImageType;
+  using HessianPixelType = typename HessianImageType::PixelType;
 
-  /** Eigenvalue analysis related typedefs. The ITK python wrapping usually wraps floating types
+  /** Eigenvalue analysis related type alias. The ITK python wrapping usually wraps floating types
    * and not double types. For this reason, the eigenvalues are of type float.
    */
-  typedef typename NumericTraits< PixelType >::RealType                               RealType;
-  typedef typename NumericTraits< PixelType >::FloatType                              FloatType;
-  typedef Vector< FloatType, HessianPixelType::Dimension >                            EigenValueArrayType;
-  typedef Image< EigenValueArrayType, TInputImage::ImageDimension >                   EigenValueImageType;
-  typedef SymmetricEigenAnalysisImageFilter< HessianImageType, EigenValueImageType >  EigenAnalysisFilterType;
+  using RealType = typename NumericTraits< PixelType >::RealType;
+  using FloatType = typename NumericTraits< PixelType >::FloatType;
+  using EigenValueArrayType = Vector< FloatType, HessianPixelType::Dimension >;
+  using EigenValueImageType = Image< EigenValueArrayType, TInputImage::ImageDimension >;
+  using EigenAnalysisFilterType = SymmetricEigenAnalysisImageFilter< HessianImageType, EigenValueImageType >;
 
-  /** Maximum over scale related typedefs. */
-  typedef MaximumAbsoluteValueImageFilter< TOutputImage > MaximumAbsoluteValueFilterType;
+  /** Maximum over scale related type alias. */
+  using MaximumAbsoluteValueFilterType = MaximumAbsoluteValueImageFilter< TOutputImage >;
 
-  /** Eigenvalue image to scalar image related typedefs */
-  typedef EigenToScalarImageFilter< EigenValueImageType, TOutputImage > EigenToScalarImageFilterType;
+  /** Eigenvalue image to scalar image related type alias */
+  using EigenToScalarImageFilterType = EigenToScalarImageFilter< EigenValueImageType, TOutputImage >;
 
   /** Need some types to determine how to order the eigenvalues */
-  // typedef typename Functor::SymmetricEigenAnalysisFunction::EigenValueOrderType InternalEigenValueOrderType;
-  typedef typename EigenAnalysisFilterType::FunctorType::EigenValueOrderType InternalEigenValueOrderType;
-  typedef typename EigenToScalarImageFilterType::EigenValueOrderType         ExternalEigenValueOrderType;
+  // using InternalEigenValueOrderType = typename Functor::SymmetricEigenAnalysisFunction::EigenValueOrderType;
+  using InternalEigenValueOrderType = typename EigenAnalysisFilterType::FunctorType::EigenValueOrderType;
+  using ExternalEigenValueOrderType = typename EigenToScalarImageFilterType::EigenValueOrderType;
 
   /** Set/Get the EigenToScalarImageFilter. */
   itkSetObjectMacro(EigenToScalarImageFilter, EigenToScalarImageFilterType);
   itkGetModifiableObjectMacro(EigenToScalarImageFilter, EigenToScalarImageFilterType);
 
   /** Sigma values. */
-  typedef RealType            SigmaType;
-  typedef Array< SigmaType >  SigmaArrayType;
-  typedef unsigned int        SigmaStepsType;
+  using SigmaType = RealType;
+  using SigmaArrayType = Array< SigmaType >;
+  using SigmaStepsType = unsigned int;
   typedef enum {
     EquispacedSigmaSteps = 0,
     LogarithmicSigmaSteps = 1

--- a/test/itkDescoteauxEigenToScalarFunctorImageTest.cxx
+++ b/test/itkDescoteauxEigenToScalarFunctorImageTest.cxx
@@ -24,16 +24,16 @@
 
 int itkDescoteauxEigenToScalarFunctorImageTest( int argc, char * argv[] )
 {
-  /* typedefs, instantiate filter */
+  /* type alias, instantiate filter */
   constexpr unsigned int Dimension = 3;
-  typedef double                                  ImagePixelType;
-  typedef itk::Image< ImagePixelType, Dimension > ImageType;
+  using ImagePixelType = double;
+  using ImageType = itk::Image< ImagePixelType, Dimension >;
 
-  typedef double                                        EigenValueType;
-  typedef itk::FixedArray< EigenValueType, Dimension >  EigenValueArrayType;
-  typedef itk::Image< EigenValueArrayType, Dimension >  EigenValueImageType;
+  using EigenValueType = double;
+  using EigenValueArrayType = itk::FixedArray< EigenValueType, Dimension >;
+  using EigenValueImageType = itk::Image< EigenValueArrayType, Dimension >;
 
-  typedef itk::DescoteauxEigenToScalarFunctorImageFilter< EigenValueImageType, ImageType> FilterType;
+  using FilterType = itk::DescoteauxEigenToScalarFunctorImageFilter< EigenValueImageType, ImageType>;
   FilterType::Pointer descoFilter = FilterType::New();
 
   /* Basic tests. Need to set parameters first. */

--- a/test/itkDescoteauxEigenToScalarFunctorTest.cxx
+++ b/test/itkDescoteauxEigenToScalarFunctorTest.cxx
@@ -21,16 +21,16 @@
 
 int itkDescoteauxEigenToScalarFunctorTest( int argc, char * argv[] )
 {
-  /* typedefs, instantiate functor */
+  /* type alias, instantiate functor */
   constexpr unsigned int Dimension = 3;
-  typedef double                                  ImagePixelType;
-  typedef itk::Image< ImagePixelType, Dimension > ImageType;
+  using ImagePixelType = double;
+  using ImageType = itk::Image< ImagePixelType, Dimension >;
 
-  typedef float                                         EigenValueType;
-  typedef itk::FixedArray< EigenValueType, Dimension >  EigenValueArrayType;
-  typedef itk::Image< EigenValueArrayType, Dimension >  EigenValueImageType;
+  using EigenValueType = float;
+  using EigenValueArrayType = itk::FixedArray< EigenValueType, Dimension >;
+  using EigenValueImageType = itk::Image< EigenValueArrayType, Dimension >;
 
-  typedef itk::Functor::DescoteauxEigenToScalarFunctor< EigenValueArrayType, ImagePixelType> FunctorType;
+  using FunctorType = itk::Functor::DescoteauxEigenToScalarFunctor< EigenValueArrayType, ImagePixelType>;
   FunctorType functor = FunctorType();
 
   /* Exercise basic set/get methods */

--- a/test/itkDescoteauxEigenToScalarImageFilterTest.cxx
+++ b/test/itkDescoteauxEigenToScalarImageFilterTest.cxx
@@ -24,17 +24,17 @@
 int itkDescoteauxEigenToScalarImageFilterTest( int argc, char * argv[] )
 {
   constexpr unsigned int Dimension = 3;
-  typedef unsigned int                            MaskPixelType;
-  typedef itk::Image< MaskPixelType, Dimension >  MaskType;
+  using MaskPixelType = unsigned int;
+  using MaskType = itk::Image< MaskPixelType, Dimension >;
 
-  typedef double                                    OutputPixelType;
-  typedef itk::Image< OutputPixelType, Dimension >  OutputType;
+  using OutputPixelType = double;
+  using OutputType = itk::Image< OutputPixelType, Dimension >;
 
-  typedef float                                         EigenValueType;
-  typedef itk::FixedArray< EigenValueType, Dimension >  EigenValueArrayType;
-  typedef itk::Image< EigenValueArrayType, Dimension >  EigenValueImageType;
+  using EigenValueType = float;
+  using EigenValueArrayType = itk::FixedArray< EigenValueType, Dimension >;
+  using EigenValueImageType = itk::Image< EigenValueArrayType, Dimension >;
   
-  typedef itk::DescoteauxEigenToScalarImageFilter< EigenValueImageType, OutputType, MaskType > DescoteauxEigenToScalarImageFilterType;
+  using DescoteauxEigenToScalarImageFilterType = itk::DescoteauxEigenToScalarImageFilter< EigenValueImageType, OutputType, MaskType >;
 
   DescoteauxEigenToScalarImageFilterType::Pointer descoFilter = DescoteauxEigenToScalarImageFilterType::New();
 

--- a/test/itkDescoteauxEigenToScalarParameterEstimationImageFilterTest.cxx
+++ b/test/itkDescoteauxEigenToScalarParameterEstimationImageFilterTest.cxx
@@ -24,14 +24,14 @@
 int itkDescoteauxEigenToScalarParameterEstimationImageFilterTest( int, char * [] )
 {
   constexpr unsigned int Dimension = 3;
-  typedef unsigned int                            MaskPixelType;
-  typedef itk::Image< MaskPixelType, Dimension >  MaskType;
+  using MaskPixelType = unsigned int;
+  using MaskType = itk::Image< MaskPixelType, Dimension >;
 
-  typedef float                                         EigenValueType;
-  typedef itk::FixedArray< EigenValueType, Dimension >  EigenValueArrayType;
-  typedef itk::Image< EigenValueArrayType, Dimension >  EigenValueImageType;
+  using EigenValueType = float;
+  using EigenValueArrayType = itk::FixedArray< EigenValueType, Dimension >;
+  using EigenValueImageType = itk::Image< EigenValueArrayType, Dimension >;
   
-  typedef itk::DescoteauxEigenToScalarParameterEstimationImageFilter<EigenValueImageType, MaskType> DescoteauxEigenToScalarParameterEstimationImageFilterType;
+  using DescoteauxEigenToScalarParameterEstimationImageFilterType = itk::DescoteauxEigenToScalarParameterEstimationImageFilter<EigenValueImageType, MaskType>;
 
   DescoteauxEigenToScalarParameterEstimationImageFilterType::Pointer descoteauxParameterEstimator = DescoteauxEigenToScalarParameterEstimationImageFilterType::New();
 

--- a/test/itkKrcahEigenToScalarFunctorImageFilterTest.cxx
+++ b/test/itkKrcahEigenToScalarFunctorImageFilterTest.cxx
@@ -24,16 +24,16 @@
 
 int itkKrcahEigenToScalarFunctorImageFilterTest( int argc, char * argv[] )
 {
-  /* typedefs, instantiate filter */
+  /* type alias, instantiate filter */
   constexpr unsigned int Dimension = 3;
-  typedef double                                  ImagePixelType;
-  typedef itk::Image< ImagePixelType, Dimension > ImageType;
+  using ImagePixelType = double;
+  using ImageType = itk::Image< ImagePixelType, Dimension >;
 
-  typedef double                                        EigenValueType;
-  typedef itk::FixedArray< EigenValueType, Dimension >  EigenValueArrayType;
-  typedef itk::Image< EigenValueArrayType, Dimension >  EigenValueImageType;
+  using EigenValueType = double;
+  using EigenValueArrayType = itk::FixedArray< EigenValueType, Dimension >;
+  using EigenValueImageType = itk::Image< EigenValueArrayType, Dimension >;
 
-  typedef itk::KrcahEigenToScalarFunctorImageFilter< EigenValueImageType, ImageType> FilterType;
+  using FilterType = itk::KrcahEigenToScalarFunctorImageFilter< EigenValueImageType, ImageType>;
   FilterType::Pointer krcahFilter = FilterType::New();
 
   /* Basic tests. Need to set parameters first. */

--- a/test/itkKrcahEigenToScalarFunctorTest.cxx
+++ b/test/itkKrcahEigenToScalarFunctorTest.cxx
@@ -21,16 +21,16 @@
 
 int itkKrcahEigenToScalarFunctorTest( int argc, char * argv[] )
 {
-  /* typedefs, instantiate functor */
+  /* type alias, instantiate functor */
   constexpr unsigned int Dimension = 3;
-  typedef double                                  ImagePixelType;
-  typedef itk::Image< ImagePixelType, Dimension > ImageType;
+  using ImagePixelType = double;
+  using ImageType = itk::Image< ImagePixelType, Dimension >;
 
-  typedef float                                         EigenValueType;
-  typedef itk::FixedArray< EigenValueType, Dimension >  EigenValueArrayType;
-  typedef itk::Image< EigenValueArrayType, Dimension >  EigenValueImageType;
+  using EigenValueType = float;
+  using EigenValueArrayType = itk::FixedArray< EigenValueType, Dimension >;
+  using EigenValueImageType = itk::Image< EigenValueArrayType, Dimension >;
 
-  typedef itk::Functor::KrcahEigenToScalarFunctor< EigenValueArrayType, ImagePixelType> FunctorType;
+  using FunctorType = itk::Functor::KrcahEigenToScalarFunctor< EigenValueArrayType, ImagePixelType>;
   FunctorType functor = FunctorType();
 
   /* Exercise basic set/get methods */

--- a/test/itkKrcahEigenToScalarImageFilterTest.cxx
+++ b/test/itkKrcahEigenToScalarImageFilterTest.cxx
@@ -24,17 +24,17 @@
 int itkKrcahEigenToScalarImageFilterTest( int argc, char * argv[] )
 {
   constexpr unsigned int Dimension = 3;
-  typedef unsigned int                            MaskPixelType;
-  typedef itk::Image< MaskPixelType, Dimension >  MaskType;
+  using MaskPixelType = unsigned int;
+  using MaskType = itk::Image< MaskPixelType, Dimension >;
 
-  typedef double                                    OutputPixelType;
-  typedef itk::Image< OutputPixelType, Dimension >  OutputType;
+  using OutputPixelType = double;
+  using OutputType = itk::Image< OutputPixelType, Dimension >;
 
-  typedef float                                         EigenValueType;
-  typedef itk::FixedArray< EigenValueType, Dimension >  EigenValueArrayType;
-  typedef itk::Image< EigenValueArrayType, Dimension >  EigenValueImageType;
+  using EigenValueType = float;
+  using EigenValueArrayType = itk::FixedArray< EigenValueType, Dimension >;
+  using EigenValueImageType = itk::Image< EigenValueArrayType, Dimension >;
   
-  typedef itk::KrcahEigenToScalarImageFilter< EigenValueImageType, OutputType, MaskType > KrcahEigenToScalarImageFilterType;
+  using KrcahEigenToScalarImageFilterType = itk::KrcahEigenToScalarImageFilter< EigenValueImageType, OutputType, MaskType >;
 
   KrcahEigenToScalarImageFilterType::Pointer krcahFilter = KrcahEigenToScalarImageFilterType::New();
 

--- a/test/itkKrcahEigenToScalarParameterEstimationImageFilterTest.cxx
+++ b/test/itkKrcahEigenToScalarParameterEstimationImageFilterTest.cxx
@@ -24,14 +24,14 @@
 int itkKrcahEigenToScalarParameterEstimationImageFilterTest( int, char * [] )
 {
   constexpr unsigned int Dimension = 3;
-  typedef unsigned int                            MaskPixelType;
-  typedef itk::Image< MaskPixelType, Dimension >  MaskType;
+  using MaskPixelType = unsigned int;
+  using MaskType = itk::Image< MaskPixelType, Dimension >;
 
-  typedef float                                         EigenValueType;
-  typedef itk::FixedArray< EigenValueType, Dimension >  EigenValueArrayType;
-  typedef itk::Image< EigenValueArrayType, Dimension >  EigenValueImageType;
+  using EigenValueType = float;
+  using EigenValueArrayType = itk::FixedArray< EigenValueType, Dimension >;
+  using EigenValueImageType = itk::Image< EigenValueArrayType, Dimension >;
   
-  typedef itk::KrcahEigenToScalarParameterEstimationImageFilter<EigenValueImageType, MaskType> KrcahEigenToScalarParameterEstimationImageFilterType;
+  using KrcahEigenToScalarParameterEstimationImageFilterType = itk::KrcahEigenToScalarParameterEstimationImageFilter<EigenValueImageType, MaskType>;
 
   KrcahEigenToScalarParameterEstimationImageFilterType::Pointer krcahParameterEstimator = KrcahEigenToScalarParameterEstimationImageFilterType::New();
 

--- a/test/itkKrcahEigenToScalarPreprocessingImageToImageFilterTest.cxx
+++ b/test/itkKrcahEigenToScalarPreprocessingImageToImageFilterTest.cxx
@@ -22,10 +22,10 @@
 int itkKrcahEigenToScalarPreprocessingImageToImageFilterTest( int, char * [] )
 {
   constexpr unsigned int Dimension = 3;
-  typedef char                                    InputPixelType;
-  typedef itk::Image< InputPixelType, Dimension > InputImageType;
+  using InputPixelType = char;
+  using InputImageType = itk::Image< InputPixelType, Dimension >;
 
-  typedef itk::KrcahEigenToScalarPreprocessingImageToImageFilter< InputImageType > FilterType;
+  using FilterType = itk::KrcahEigenToScalarPreprocessingImageToImageFilter< InputImageType >;
   FilterType::Pointer filter = FilterType::New();
 
   /* Basic test */

--- a/test/itkMaximumAbsoluteValueImageFilterTest.cxx
+++ b/test/itkMaximumAbsoluteValueImageFilterTest.cxx
@@ -23,9 +23,9 @@
 int itkMaximumAbsoluteValueImageFilterTest( int, char * [] )
 {
   constexpr unsigned int Dimension = 2;
-  typedef int                                PixelType;
-  typedef itk::Image< PixelType, Dimension > ImageType;
-  typedef itk::MaximumAbsoluteValueImageFilter<ImageType> MaximumAbsoluteValueImageFilterType;
+  using PixelType = int;
+  using ImageType = itk::Image< PixelType, Dimension >;
+  using MaximumAbsoluteValueImageFilterType = itk::MaximumAbsoluteValueImageFilter<ImageType>;
   MaximumAbsoluteValueImageFilterType::Pointer maxAbsFilter = MaximumAbsoluteValueImageFilterType::New();
   
   EXERCISE_BASIC_OBJECT_METHODS( maxAbsFilter, MaximumAbsoluteValueImageFilter, BinaryFunctorImageFilter );
@@ -52,7 +52,7 @@ int itkMaximumAbsoluteValueImageFilterTest( int, char * [] )
   image2->SetRegions(region);
   image2->Allocate();
 
-  typedef itk::ImageRegionIterator< ImageType > IteratorType;
+  using IteratorType = itk::ImageRegionIterator< ImageType >;
   IteratorType  it1( image1, region);
   IteratorType  it2( image2, region);
   it1.GoToBegin();

--- a/test/itkMultiScaleHessianEnhancementImageFilterStaticMethodsTest.cxx
+++ b/test/itkMultiScaleHessianEnhancementImageFilterStaticMethodsTest.cxx
@@ -24,10 +24,10 @@
 int itkMultiScaleHessianEnhancementImageFilterStaticMethodsTest( int, char * [] )
 {
   constexpr unsigned int Dimension = 2;
-  typedef int                                PixelType;
-  typedef itk::Image< PixelType, Dimension > ImageType;
-  typedef itk::MultiScaleHessianEnhancementImageFilter<ImageType> MultiScaleHessianEnhancementImageFilterType;
-  typedef MultiScaleHessianEnhancementImageFilterType::SigmaArrayType ArrayType;
+  using PixelType = int;
+  using ImageType = itk::Image< PixelType, Dimension >;
+  using MultiScaleHessianEnhancementImageFilterType = itk::MultiScaleHessianEnhancementImageFilter<ImageType>;
+  using ArrayType = MultiScaleHessianEnhancementImageFilterType::SigmaArrayType;
 
   /* Test the two cases of step size zero */
   ArrayType sigmaArray;


### PR DESCRIPTION
Prefer C++11 type alias over `typedef` for the reasons stated here:
http://review.source.kitware.com/#/c/23103/