### PR TITLE
STYLE: Prefer error checked std::sto[id] over ato[if].

### DIFF
--- a/example/computeDescoteauxBoneEnhancement.cxx
+++ b/example/computeDescoteauxBoneEnhancement.cxx
@@ -55,13 +55,13 @@ int main(int argc, char * argv[])
   std::string inputFileName = argv[1];
   std::string outputMeasureFileName = argv[2];
 
-  int enhanceBrightObjects = atoi(argv[3]);
-  int numberOfSigma = atoi(argv[4]);
+  int enhanceBrightObjects = std::stoi(argv[3]);
+  int numberOfSigma = std::stoi(argv[4]);
   double thisSigma;
   itk::Array< double > sigmaArray;
   sigmaArray.SetSize(numberOfSigma);
   for (unsigned int i = 0; i < numberOfSigma; ++i) {
-    thisSigma = atof(argv[5+i]);
+    thisSigma = std::stod(argv[5+i]);
     sigmaArray.SetElement(i, thisSigma);
   }
 

--- a/example/computeKrcahBoneEnhancement.cxx
+++ b/example/computeKrcahBoneEnhancement.cxx
@@ -58,14 +58,14 @@ int main(int argc, char * argv[])
   std::string outputPreprocessedFileName = argv[2];
   std::string outputMeasureFileName = argv[3];
 
-  int enhanceBrightObjects = atoi(argv[4]);
-  int parameterSetToImplement = atoi(argv[5]);
-  int numberOfSigma = atoi(argv[6]);
+  int enhanceBrightObjects = std::stoi(argv[4]);
+  int parameterSetToImplement = std::stoi(argv[5]);
+  int numberOfSigma = std::stoi(argv[6]);
   double thisSigma;
   itk::Array< double > sigmaArray;
   sigmaArray.SetSize(numberOfSigma);
   for (unsigned int i = 0; i < numberOfSigma; ++i) {
-    thisSigma = atof(argv[7+i]);
+    thisSigma = std::stod(argv[7+i]);
     sigmaArray.SetElement(i, thisSigma);
   }
 


### PR DESCRIPTION
The `ato[if]` functions do not provide mechanisms for distinguishing
between `0` and the error condition where the input can not be converted.

`std::sto[id]` provides exception handling and detects when an invalid
string attempts to be converted to an [integer|double].

`ato[if]()`
 - **Con**: No error handling.
 - **Con**: Handle neither hexadecimal nor octal.

The use of `ato[if]` in code can cause it to be subtly broken.
`ato[if]` makes two very big assumptions indeed:
 - The string represents an integer/floating point value.
 - The integer can fit into an int.

In agreement with:
http://review.source.kitware.com/#/c/23738/