### PR TITLE
COMP: Use directly std::exp instead of the wrapper vcl_exp

### DIFF
--- a/include/itkDescoteauxEigenToScalarFunctorImageFilter.h
+++ b/include/itkDescoteauxEigenToScalarFunctorImageFilter.h
@@ -84,9 +84,9 @@ public:
 
     /* Multiply together to get sheetness */
     sheetness = 1.0;
-    sheetness *= vcl_exp(-(Rsheet * Rsheet) / (2 * m_Alpha * m_Alpha));
-    sheetness *= (1.0 - vcl_exp(-(Rblob * Rblob) / (2 * m_Beta * m_Beta)));
-    sheetness *= (1.0 - vcl_exp(-(Rnoise * Rnoise) / (2 * m_C * m_C)));
+    sheetness *= std::exp(-(Rsheet * Rsheet) / (2 * m_Alpha * m_Alpha));
+    sheetness *= (1.0 - std::exp(-(Rblob * Rblob) / (2 * m_Beta * m_Beta)));
+    sheetness *= (1.0 - std::exp(-(Rnoise * Rnoise) / (2 * m_C * m_C)));
 
     return static_cast<TOutputPixel>( sheetness );
   }

--- a/include/itkKrcahEigenToScalarFunctorImageFilter.h
+++ b/include/itkKrcahEigenToScalarFunctorImageFilter.h
@@ -79,9 +79,9 @@ public:
 
     /* Multiply together to get sheetness */
     sheetness = (m_Direction*a3/l3);
-    sheetness *= vcl_exp(-(Rsheet * Rsheet) / (m_Alpha * m_Alpha));
-    sheetness *= vcl_exp(-(Rtube * Rtube) / (m_Beta * m_Beta));
-    sheetness *= (1.0 - vcl_exp(-(Rnoise * Rnoise) / (m_Gamma * m_Gamma)));
+    sheetness *= std::exp(-(Rsheet * Rsheet) / (m_Alpha * m_Alpha));
+    sheetness *= std::exp(-(Rtube * Rtube) / (m_Beta * m_Beta));
+    sheetness *= (1.0 - std::exp(-(Rnoise * Rnoise) / (m_Gamma * m_Gamma)));
 
     return static_cast<TOutputPixel>( sheetness );
   }

--- a/include/itkKrcahEigenToScalarPreprocessingImageToImageFilter.h
+++ b/include/itkKrcahEigenToScalarPreprocessingImageToImageFilter.h
@@ -105,7 +105,7 @@ public:
    * provide an implementation for GenerateInputRequestedRegion() in
    * order to inform the pipeline execution model.
    * \sa ImageToImageFilter::GenerateInputRequestedRegion() */
-  virtual void GenerateInputRequestedRegion() throw( InvalidRequestedRegionError );
+  virtual void GenerateInputRequestedRegion();
   
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/include/itkKrcahEigenToScalarPreprocessingImageToImageFilter.hxx
+++ b/include/itkKrcahEigenToScalarPreprocessingImageToImageFilter.hxx
@@ -46,7 +46,6 @@ template< typename TInputImage, typename TOutputImage >
 void
 KrcahEigenToScalarPreprocessingImageToImageFilter< TInputImage, TOutputImage >
 ::GenerateInputRequestedRegion()
-throw( InvalidRequestedRegionError )
 {
   // This implementation is copied from itkDiscreteGaussianImageFilter
 


### PR DESCRIPTION
Also remove deprecated throw signature in GenerateInputRequestedRegion