### PR TITLE
WIP:BUG: Fixes failing doxygen test

### DIFF
--- a/include/itkEigenToMeasureImageFilter.h
+++ b/include/itkEigenToMeasureImageFilter.h
@@ -86,6 +86,7 @@ public:
   itkGetInputMacro(Mask, MaskSpatialObjectType);
 
   /**\class EigenValueOrderEnum
+   * \ingroup BoneEnhancement
    * Template the EigenValueOrderEnum. Methods that inherit from this class can override this function
    * to produce a different eigenvalue ordering. Ideally, the enum EigenValueOrderEnum should come from
    * itkSymmetricEigenAnalysisImageFilter.h or itkSymmetricEigenAnalysis.h. That turns out to be non-trivial

--- a/include/itkKrcahEigenToMeasureParameterEstimationFilter.h
+++ b/include/itkKrcahEigenToMeasureParameterEstimationFilter.h
@@ -116,6 +116,7 @@ public:
   itkTypeMacro(KrcahEigenToMeasureParameterEstimationFilter, EigenToMeasureParameterEstimationFilter);
 
   /***\class KrcahImplementationEnum
+   * \ingroup BoneEnhancement
    * Krcah implementation type
    */
   enum class KrcahImplementationEnum : uint8_t

--- a/include/itkMultiScaleHessianEnhancementImageFilter.h
+++ b/include/itkMultiScaleHessianEnhancementImageFilter.h
@@ -142,6 +142,7 @@ public:
   using SigmaArrayType = Array<SigmaType>;
   using SigmaStepsType = unsigned int;
   /**\class SigmaStepMethodEnum
+   * \ingroup BoneEnhancement
    * */
   enum class SigmaStepMethodEnum : uint8_t
   {

--- a/test/itkDescoteauxEigenToMeasureImageFilterUnitTest.cxx
+++ b/test/itkDescoteauxEigenToMeasureImageFilterUnitTest.cxx
@@ -164,7 +164,7 @@ protected:
 
 // Define the templates we would like to test
 using TestingLabelTypes = ::testing::Types<double, float>;
-TYPED_TEST_CASE(itkDescoteauxEigenToMeasureImageFilterUnitTest, TestingLabelTypes);
+TYPED_TEST_SUITE(itkDescoteauxEigenToMeasureImageFilterUnitTest, TestingLabelTypes);
 
 TYPED_TEST(itkDescoteauxEigenToMeasureImageFilterUnitTest, InitialParameters)
 {

--- a/test/itkDescoteauxEigenToMeasureParameterEstimationFilterUnitTest.cxx
+++ b/test/itkDescoteauxEigenToMeasureParameterEstimationFilterUnitTest.cxx
@@ -146,7 +146,7 @@ protected:
 
 // Define the templates we would like to test
 using TestingLabelTypes = ::testing::Types<double, float>;
-TYPED_TEST_CASE(itkDescoteauxEigenToMeasureParameterEstimationFilterUnitTest, TestingLabelTypes);
+TYPED_TEST_SUITE(itkDescoteauxEigenToMeasureParameterEstimationFilterUnitTest, TestingLabelTypes);
 
 TYPED_TEST(itkDescoteauxEigenToMeasureParameterEstimationFilterUnitTest, InitialParameters)
 {

--- a/test/itkKrcahEigenToMeasureParameterEstimationFilterUnitTest.cxx
+++ b/test/itkKrcahEigenToMeasureParameterEstimationFilterUnitTest.cxx
@@ -146,7 +146,7 @@ protected:
 
 // Define the templates we would like to test
 using TestingLabelTypes = ::testing::Types<double, float>;
-TYPED_TEST_CASE(itkKrcahEigenToMeasureParameterEstimationFilterUnitTest, TestingLabelTypes);
+TYPED_TEST_SUITE(itkKrcahEigenToMeasureParameterEstimationFilterUnitTest, TestingLabelTypes);
 
 TYPED_TEST(itkKrcahEigenToMeasureParameterEstimationFilterUnitTest, InitialParameters)
 {


### PR DESCRIPTION
This patch fixes the failing doxygen test. For several of the new enum classes, there is an absent `/ingroup` thus throwing the error.