### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_AND_MOVE

### DIFF
--- a/include/itkDescoteauxEigenToMeasureImageFilter.h
+++ b/include/itkDescoteauxEigenToMeasureImageFilter.h
@@ -52,7 +52,7 @@ template <typename TInputImage, typename TOutputImage>
 class DescoteauxEigenToMeasureImageFilter : public EigenToMeasureImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(DescoteauxEigenToMeasureImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(DescoteauxEigenToMeasureImageFilter);
 
   /** Standard Self typedef */
   using Self = DescoteauxEigenToMeasureImageFilter;

--- a/include/itkDescoteauxEigenToMeasureParameterEstimationFilter.h
+++ b/include/itkDescoteauxEigenToMeasureParameterEstimationFilter.h
@@ -54,7 +54,7 @@ class DescoteauxEigenToMeasureParameterEstimationFilter
   : public EigenToMeasureParameterEstimationFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(DescoteauxEigenToMeasureParameterEstimationFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(DescoteauxEigenToMeasureParameterEstimationFilter);
 
   /** Standard Self typedef */
   using Self = DescoteauxEigenToMeasureParameterEstimationFilter;

--- a/include/itkEigenToMeasureImageFilter.h
+++ b/include/itkEigenToMeasureImageFilter.h
@@ -42,7 +42,7 @@ template <typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT EigenToMeasureImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(EigenToMeasureImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(EigenToMeasureImageFilter);
 
   /** Standard Self typedef */
   using Self = EigenToMeasureImageFilter;

--- a/include/itkEigenToMeasureParameterEstimationFilter.h
+++ b/include/itkEigenToMeasureParameterEstimationFilter.h
@@ -52,7 +52,7 @@ class ITK_TEMPLATE_EXPORT EigenToMeasureParameterEstimationFilter
   : public StreamingImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(EigenToMeasureParameterEstimationFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(EigenToMeasureParameterEstimationFilter);
 
   /** Standard Self typedef */
   using Self = EigenToMeasureParameterEstimationFilter;

--- a/include/itkHessianGaussianImageFilter.h
+++ b/include/itkHessianGaussianImageFilter.h
@@ -54,7 +54,7 @@ template <typename TInputImage,
 class ITK_TEMPLATE_EXPORT HessianGaussianImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(HessianGaussianImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(HessianGaussianImageFilter);
 
   /** Standard Self typedef */
   using Self = HessianGaussianImageFilter;

--- a/include/itkKrcahEigenToMeasureImageFilter.h
+++ b/include/itkKrcahEigenToMeasureImageFilter.h
@@ -52,7 +52,7 @@ template <typename TInputImage, typename TOutputImage>
 class KrcahEigenToMeasureImageFilter : public EigenToMeasureImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(KrcahEigenToMeasureImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(KrcahEigenToMeasureImageFilter);
 
   /** Standard Self typedef */
   using Self = KrcahEigenToMeasureImageFilter;

--- a/include/itkKrcahEigenToMeasureParameterEstimationFilter.h
+++ b/include/itkKrcahEigenToMeasureParameterEstimationFilter.h
@@ -79,7 +79,7 @@ class KrcahEigenToMeasureParameterEstimationFilter
   : public EigenToMeasureParameterEstimationFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(KrcahEigenToMeasureParameterEstimationFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(KrcahEigenToMeasureParameterEstimationFilter);
 
   /** Standard Self typedef */
   using Self = KrcahEigenToMeasureParameterEstimationFilter;

--- a/include/itkKrcahPreprocessingImageToImageFilter.h
+++ b/include/itkKrcahPreprocessingImageToImageFilter.h
@@ -55,7 +55,7 @@ template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT KrcahPreprocessingImageToImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(KrcahPreprocessingImageToImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(KrcahPreprocessingImageToImageFilter);
 
   /** Standard Self type alias */
   using Self = KrcahPreprocessingImageToImageFilter;

--- a/include/itkMaximumAbsoluteValueImageFilter.h
+++ b/include/itkMaximumAbsoluteValueImageFilter.h
@@ -90,7 +90,7 @@ class ITK_TEMPLATE_EXPORT MaximumAbsoluteValueImageFilter
                                                                   typename TOutputImage::PixelType>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MaximumAbsoluteValueImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(MaximumAbsoluteValueImageFilter);
 
   /** Standard Self type alias */
   using Self = MaximumAbsoluteValueImageFilter;

--- a/include/itkMultiScaleHessianEnhancementImageFilter.h
+++ b/include/itkMultiScaleHessianEnhancementImageFilter.h
@@ -65,7 +65,7 @@ template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT MultiScaleHessianEnhancementImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MultiScaleHessianEnhancementImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(MultiScaleHessianEnhancementImageFilter);
 
   /** Standard Self type alias */
   using Self = MultiScaleHessianEnhancementImageFilter;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.