### PR TITLE
ENH: Update GitHub actions

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -100,6 +100,9 @@ jobs:
         set(dashboard_no_clean 1)
         set(ENV{CC} ${{ matrix.c-compiler }})
         set(ENV{CXX} ${{ matrix.cxx-compiler }})
+        if(WIN32)
+          set(ENV{PATH} "\${CTEST_DASHBOARD_ROOT}/ITK-build/bin;\$ENV{PATH}")
+        endif()
         set(dashboard_cache "
         ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
         BUILD_TESTING:BOOL=ON

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -131,7 +131,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [35, 36, 37, 38]
+        python-version: [36, 37, 38, 39]
         include:
           - itk-python-git-tag: "v5.1.1.post1"
 
@@ -196,7 +196,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version-minor: [5, 6, 7, 8]
+        python-version-minor: [6, 7, 8, 9]
         include:
           - itk-python-git-tag: "v5.1.1.post1"
 

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "v5.1.0"
+            itk-git-tag: "v5.1.1"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "v5.1.0"
+            itk-git-tag: "v5.1.1"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "v5.1.0"
+            itk-git-tag: "v5.1.1"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -130,7 +130,7 @@ jobs:
       matrix:
         python-version: [35, 36, 37, 38]
         include:
-          - itk-python-git-tag: "v5.1.0.post3"
+          - itk-python-git-tag: "v5.1.1.post1"
 
     steps:
     - uses: actions/checkout@v2
@@ -166,7 +166,7 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.1.0.post3"
+          - itk-python-git-tag: "v5.1.1.post1"
 
     steps:
     - uses: actions/checkout@v2
@@ -195,7 +195,7 @@ jobs:
       matrix:
         python-version-minor: [5, 6, 7, 8]
         include:
-          - itk-python-git-tag: "v5.1.0.post3"
+          - itk-python-git-tag: "v5.1.1.post1"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -1,0 +1,13 @@
+name: clang-format linter
+
+on: [push,pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master

--- a/include/itkEigenToMeasureImageFilter.hxx
+++ b/include/itkEigenToMeasureImageFilter.hxx
@@ -38,7 +38,7 @@ EigenToMeasureImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   this->BeforeThreadedGenerateData();
 
-  const OutputImageRegionType requestedRegion( outputPtr->GetRequestedRegion() );
+  const OutputImageRegionType requestedRegion(outputPtr->GetRequestedRegion());
 
   // Define the portion of the input to walk for this thread, using
   // the CallCopyOutputRegionToInputRegion method allows for the input

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 
 setup(
     name='itk-boneenhancement',
-    version='0.3.1',
+    version='0.4.0',
     author='Bryce A. Besler',
     author_email='babesler@ucalgary.ca',
     packages=['itk'],

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(
     keywords='ITK InsightToolkit',
     url=r'https://itk.org/',
     install_requires=[
-        r'itk>=5.1.0.post3'
+        r'itk>=5.1.1'
     ]
     )


### PR DESCRIPTION
### Description
This PR will update this module with recent changes made to the `ITKModuleTemplate`. These changes include the following.

#### Changes
- Bump ITK version to `v5.1.1` and ITK Python Package version to `5.1.1.post`
- Adding ITK runtime directory in `PATH` for Windows `cxx` build
- Update the supported Python versions
      -  New support minimum: `3.6`
      -  New supported maximum: `3.9`
      - Update `setup.py` to use ITK `v5.1.1`
- Bumping package version in `setup.py` from `0.3.1` to `0.4.0`
- Integrate `clang-format-linter.yml` which will test if the proposed changes adhere to the `clang` style
- Fix `clang` styling for module

### Closing Remarks
Once this branch is merged, a new tag `v0.4.0` will need to be created. Also, the `cxx` builds will fail as they have not yet been fixed in #26.