### PR TITLE
COMP: Tests depend on GTest

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -22,6 +22,7 @@ itk_module(BoneEnhancement
     ITKImageSources
   TEST_DEPENDS
     ITKTestKernel
+    ITKGoogleTest
     ITKMetaIO
   DESCRIPTION
     "${DOCUMENTATION}"


### PR DESCRIPTION
ITK_BUILD_DEFAULT_MODULES=OFF produces:

CMake Error at CMake/ITKModuleTest.cmake:250 (add_executable):
  Target "BoneEnhancementUnitTestsGTestDriver" links to target "GTest::GTest"
  but the target was not found.  Perhaps a find_package() call is missing for
  an IMPORTED target, or an ALIAS target is missing?
Call Stack (most recent call first):
  Modules/Remote/BoneEnhancement/test/CMakeLists.txt:22 (CreateGoogleTestDriver)