### PR TITLE
remove recursive header includes

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "v5.2.0"
+            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "v5.2.0"
+            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "v5.2.0"
+            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
             cmake-build-type: "MinSizeRel"
 
     steps:

--- a/include/itkDescoteauxEigenToMeasureImageFilter.hxx
+++ b/include/itkDescoteauxEigenToMeasureImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkDescoteauxEigenToMeasureImageFilter_hxx
 #define itkDescoteauxEigenToMeasureImageFilter_hxx
 
-#include "itkDescoteauxEigenToMeasureImageFilter.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
 
@@ -56,9 +55,9 @@ DescoteauxEigenToMeasureImageFilter<TInputImage, TOutputImage>::ProcessPixel(con
   auto   a1 = static_cast<double>(pixel[0]);
   auto   a2 = static_cast<double>(pixel[1]);
   auto   a3 = static_cast<double>(pixel[2]);
-  double l1 = Math::abs(a1);
-  double l2 = Math::abs(a2);
-  double l3 = Math::abs(a3);
+  double l1 = itk::Math::abs(a1);
+  double l2 = itk::Math::abs(a2);
+  double l3 = itk::Math::abs(a3);
 
   /* Deal with l3 > 0 */
   if (m_EnhanceType * a3 < 0)
@@ -74,7 +73,7 @@ DescoteauxEigenToMeasureImageFilter<TInputImage, TOutputImage>::ProcessPixel(con
 
   /* Compute measures */
   const double Rsheet = l2 / l3;
-  const double Rblob = Math::abs(2 * l3 - l2 - l1) / l3;
+  const double Rblob = itk::Math::abs(2 * l3 - l2 - l1) / l3;
   const double Rnoise = sqrt(l1 * l1 + l2 * l2 + l3 * l3);
 
   /* Multiply together to get sheetness */

--- a/include/itkDescoteauxEigenToMeasureParameterEstimationFilter.hxx
+++ b/include/itkDescoteauxEigenToMeasureParameterEstimationFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkDescoteauxEigenToMeasureParameterEstimationFilter_hxx
 #define itkDescoteauxEigenToMeasureParameterEstimationFilter_hxx
 
-#include "itkDescoteauxEigenToMeasureParameterEstimationFilter.h"
 
 namespace itk
 {

--- a/include/itkEigenToMeasureImageFilter.hxx
+++ b/include/itkEigenToMeasureImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkEigenToMeasureImageFilter_hxx
 #define itkEigenToMeasureImageFilter_hxx
 
-#include "itkEigenToMeasureImageFilter.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
 

--- a/include/itkEigenToMeasureParameterEstimationFilter.hxx
+++ b/include/itkEigenToMeasureParameterEstimationFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkEigenToMeasureParameterEstimationFilter_hxx
 #define itkEigenToMeasureParameterEstimationFilter_hxx
 
-#include "itkEigenToMeasureParameterEstimationFilter.h"
 #include "itkCommand.h"
 #include "itkImageAlgorithm.h"
 #include "itkImageRegionSplitterSlowDimension.h"

--- a/include/itkHessianGaussianImageFilter.hxx
+++ b/include/itkHessianGaussianImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkHessianGaussianImageFilter_hxx
 #define itkHessianGaussianImageFilter_hxx
 
-#include "itkHessianGaussianImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkProgressAccumulator.h"
 #include "itkGaussianDerivativeOperator.h"

--- a/include/itkKrcahEigenToMeasureImageFilter.hxx
+++ b/include/itkKrcahEigenToMeasureImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkKrcahEigenToMeasureImageFilter_hxx
 #define itkKrcahEigenToMeasureImageFilter_hxx
 
-#include "itkKrcahEigenToMeasureImageFilter.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
 
@@ -57,9 +56,9 @@ KrcahEigenToMeasureImageFilter<TInputImage, TOutputImage>::ProcessPixel(const In
   auto   a1 = static_cast<double>(pixel[0]);
   auto   a2 = static_cast<double>(pixel[1]);
   auto   a3 = static_cast<double>(pixel[2]);
-  double l1 = Math::abs(a1);
-  double l2 = Math::abs(a2);
-  double l3 = Math::abs(a3);
+  double l1 = itk::Math::abs(a1);
+  double l2 = itk::Math::abs(a2);
+  double l3 = itk::Math::abs(a3);
 
   /* Avoid divisions by zero (or close to zero) */
   if (static_cast<double>(l3) < Math::eps || static_cast<double>(l2) < Math::eps)

--- a/include/itkKrcahEigenToMeasureParameterEstimationFilter.hxx
+++ b/include/itkKrcahEigenToMeasureParameterEstimationFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkKrcahEigenToMeasureParameterEstimationFilter_hxx
 #define itkKrcahEigenToMeasureParameterEstimationFilter_hxx
 
-#include "itkKrcahEigenToMeasureParameterEstimationFilter.h"
 
 namespace itk
 {
@@ -182,7 +181,7 @@ KrcahEigenToMeasureParameterEstimationFilter<TInputImage, TOutputImage>::Calcula
   RealType trace = 0;
   for (unsigned int i = 0; i < pixel.Length; ++i)
   {
-    trace += Math::abs(pixel[i]);
+    trace += itk::Math::abs(pixel[i]);
   }
   return trace;
 }

--- a/include/itkKrcahPreprocessingImageToImageFilter.hxx
+++ b/include/itkKrcahPreprocessingImageToImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkKrcahPreprocessingImageToImageFilter_hxx
 #define itkKrcahPreprocessingImageToImageFilter_hxx
 
-#include "itkKrcahPreprocessingImageToImageFilter.h"
 #include "itkGaussianOperator.h"
 #include "itkMath.h"
 

--- a/include/itkMaximumAbsoluteValueImageFilter.h
+++ b/include/itkMaximumAbsoluteValueImageFilter.h
@@ -62,7 +62,7 @@ public:
   inline TOutputPixel
   operator()(const TInputPixel1 A, const TInputPixel2 B)
   {
-    return static_cast<TOutputPixel>(Math::abs(A) > Math::abs(B) ? A : B);
+    return static_cast<TOutputPixel>(itk::Math::abs(A) > itk::Math::abs(B) ? A : B);
   }
 }; // end of class
 } // namespace Functor

--- a/include/itkMultiScaleHessianEnhancementImageFilter.hxx
+++ b/include/itkMultiScaleHessianEnhancementImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkMultiScaleHessianEnhancementImageFilter_hxx
 #define itkMultiScaleHessianEnhancementImageFilter_hxx
 
-#include "itkMultiScaleHessianEnhancementImageFilter.h"
 #include "itkMath.h"
 #include "itkProgressAccumulator.h"
 


### PR DESCRIPTION
COMP: Modules need updated version of ITK

Removal of .h includes from same named .hxx files
requires removal of outdated rule that is no longer
relevant.

This PR will update the version of ITK that is
used for the remove modules."



BRANCH_NAME=update-reference-itk-version
for remdir_script in *.remote.cmake; do
   
  remdir="${remdir_script//*.remote.cmake/}"
  if [ ! -d "${remdir}" ] ;then
    echo "Missing directory ${remdir}"
    continue
  fi
  pushd "${remdir}" || exit
  echo "=============== $(pwd) ========="
  git checkout master
  git fetch origin
  git rebase origin/master
  git checkout -b ${BRANCH_NAME}
  sed 's/itk-git-tag : .*/itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"/g' $( fgrep -Rl "itk-git-tag:" |fgrep yml )

  git status
  diff_line_no=$(git diff |wc -l )
  if [ "${diff_line_no}" -ne 0 ]; then
    git add -p
    git commit -F /tmp/update_itk_msg

    gh pr create -a "@me" -F /tmp/update_itk_msg
  else
    echo "Skipping changes $(pwd)"
  fi
  git fetch
  git rebase origin/master 
  git push origin -f ${BRANCH_NAME}:${BRANCH_NAME}

  popd || exit
done
