### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/include/itkDescoteauxEigenToMeasureImageFilter.h
+++ b/include/itkDescoteauxEigenToMeasureImageFilter.h
@@ -82,7 +82,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(DescoteauxEigenToMeasureImageFilter, EigenToMeasureImageFilter);
+  itkOverrideGetNameOfClassMacro(DescoteauxEigenToMeasureImageFilter);
 
   /** Explicitely state the eigenvalues are ordered by magnitude for this filter */
   typename Superclass::EigenValueOrderEnum

--- a/include/itkDescoteauxEigenToMeasureParameterEstimationFilter.h
+++ b/include/itkDescoteauxEigenToMeasureParameterEstimationFilter.h
@@ -88,7 +88,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(DescoteauxEigenToMeasureParameterEstimationFilter, EigenToMeasureParameterEstimationFilter);
+  itkOverrideGetNameOfClassMacro(DescoteauxEigenToMeasureParameterEstimationFilter);
 
   /** Setter/Getter methods for setting FrobeniusNormWeight */
   itkSetMacro(FrobeniusNormWeight, RealType);

--- a/include/itkEigenToMeasureImageFilter.h
+++ b/include/itkEigenToMeasureImageFilter.h
@@ -51,7 +51,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(EigenToMeasureImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(EigenToMeasureImageFilter);
 
   /** Input Image typedefs. */
   using InputImageType = TInputImage;

--- a/include/itkEigenToMeasureParameterEstimationFilter.h
+++ b/include/itkEigenToMeasureParameterEstimationFilter.h
@@ -70,7 +70,7 @@ public:
   using InputImageRegionType = typename InputImageType::RegionType;
   using InputImagePixelType = typename InputImageType::PixelType;
   using PixelValueType = typename InputImagePixelType::ValueType;
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Output image typedefs. */
   using OutputImageType = TOutputImage;

--- a/include/itkEigenToMeasureParameterEstimationFilter.h
+++ b/include/itkEigenToMeasureParameterEstimationFilter.h
@@ -61,7 +61,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(EigenToMeasureParameterEstimationFilter, StreamingImageFilter);
+  itkOverrideGetNameOfClassMacro(EigenToMeasureParameterEstimationFilter);
 
   /** Input Image typedefs. */
   using InputImageType = TInputImage;

--- a/include/itkHessianGaussianImageFilter.h
+++ b/include/itkHessianGaussianImageFilter.h
@@ -68,7 +68,7 @@ public:
   using RealType = typename NumericTraits<PixelType>::RealType;
 
   /** Image dimension. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Define the image type for internal computations
       RealType is usually 'double' in NumericTraits.

--- a/include/itkHessianGaussianImageFilter.h
+++ b/include/itkHessianGaussianImageFilter.h
@@ -98,7 +98,7 @@ public:
   using OutputComponentType = typename PixelTraits<OutputPixelType>::ValueType;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(HessianGaussianImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(HessianGaussianImageFilter);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/itkKrcahEigenToMeasureImageFilter.h
+++ b/include/itkKrcahEigenToMeasureImageFilter.h
@@ -82,7 +82,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(KrcahEigenToMeasureImageFilter, EigenToMeasureImageFilter);
+  itkOverrideGetNameOfClassMacro(KrcahEigenToMeasureImageFilter);
 
   /** Explicitely state the eigenvalues are ordered by magnitude for this filter */
   typename Superclass::EigenValueOrderEnum

--- a/include/itkKrcahEigenToMeasureParameterEstimationFilter.h
+++ b/include/itkKrcahEigenToMeasureParameterEstimationFilter.h
@@ -113,7 +113,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(KrcahEigenToMeasureParameterEstimationFilter, EigenToMeasureParameterEstimationFilter);
+  itkOverrideGetNameOfClassMacro(KrcahEigenToMeasureParameterEstimationFilter);
 
   /***\class KrcahImplementationEnum
    * Krcah implementation type

--- a/include/itkKrcahPreprocessingImageToImageFilter.h
+++ b/include/itkKrcahPreprocessingImageToImageFilter.h
@@ -67,7 +67,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(KrcahPreprocessingImageToImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(KrcahPreprocessingImageToImageFilter);
 
   /** Extract some information from the image types.  Dimensionality
    * of the two images is assumed to be the same. */

--- a/include/itkMaximumAbsoluteValueImageFilter.h
+++ b/include/itkMaximumAbsoluteValueImageFilter.h
@@ -110,7 +110,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(MaximumAbsoluteValueImageFilter, BinaryFunctorImageFilter);
+  itkOverrideGetNameOfClassMacro(MaximumAbsoluteValueImageFilter);
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
   itkConceptMacro(Input1ConvertableToOutputCheck, (Concept::Convertible<Input1PixelType, OutputPixelType>));

--- a/include/itkMultiScaleHessianEnhancementImageFilter.h
+++ b/include/itkMultiScaleHessianEnhancementImageFilter.h
@@ -85,7 +85,7 @@ public:
   using InputImageConstPointer = typename InputImageType::ConstPointer;
   using InputImageRegionType = typename InputImageType::RegionType;
   using InputImagePixelType = typename InputImageType::PixelType;
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Output image typedefs. */
   using OutputImageType = TOutputImage;

--- a/include/itkMultiScaleHessianEnhancementImageFilter.h
+++ b/include/itkMultiScaleHessianEnhancementImageFilter.h
@@ -77,7 +77,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(MultiScaleHessianEnhancementImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(MultiScaleHessianEnhancementImageFilter);
 
   /** Input Image typedefs. */
   using InputImageType = TInputImage;


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
