### PR TITLE
COMP: Suppress -Wunused-parameter in HessianGaussianImageFilterTest

### DIFF
--- a/test/itkHessianGaussianImageFilterTest.cxx
+++ b/test/itkHessianGaussianImageFilterTest.cxx
@@ -23,7 +23,7 @@
 #include "itkMath.h"
 
 int
-itkHessianGaussianImageFilterTest(int argc, char * argv[])
+itkHessianGaussianImageFilterTest(int, char *[])
 {
   const unsigned int Dimension = 2;
   using PixelType = int;


### PR DESCRIPTION
Drop the unused `argc` / `argv` parameter names in the CTest entry-point signature; the driver still supplies the arguments, this test simply does not inspect them.

<details>
<summary>Warning being fixed</summary>

```
itkHessianGaussianImageFilterTest.cxx:26:39: warning: unused parameter 'argc' [-Wunused-parameter]
itkHessianGaussianImageFilterTest.cxx:26:52: warning: unused parameter 'argv' [-Wunused-parameter]
```
</details>

<!--
provenance: claude-code session 2026-04-24
related_files: test/itkHessianGaussianImageFilterTest.cxx:26
-->